### PR TITLE
C++17 compatibility

### DIFF
--- a/ext/geographiclib/GeographicLib/Geoid.hpp
+++ b/ext/geographiclib/GeographicLib/Geoid.hpp
@@ -123,7 +123,7 @@ namespace GeographicLib {
       _file.seekg(
 #if !(defined(__GNUC__) && __GNUC__ < 4)
                   // g++ 3.x doesn't know about the cast to streamoff.
-                  std::ios::streamoff
+                  std::streamoff
 #endif
                   (_datastart +
                    pixel_size_ * (unsigned(iy)*_swidth + unsigned(ix))));


### PR DESCRIPTION
## Problem
When trying to install the gem `geographiclib`, I encountered the following error:

error: ‘streamoff’ is not a member of ‘std::ios’

## Solution
The error is caused by the use of `std::ios::streamoff`, which is not defined in C++17. According to the C++17 standard, `std::streamoff` should be used instead. I have replaced `std::ios::streamoff` with `std::streamoff` to fix this error.

## References
- https://sourceforge.net/p/geographiclib/discussion/1026621/thread/962b6bd5/
- https://stackoverflow.com/questions/68985402/is-stdstreampos-source-compatible-with-stdios-basestreampos
